### PR TITLE
Add basic Next.js site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# codeXSite
-codeXSite
+# AIDD Official Site
+
+这是基于 **Next.js** 框架的 AIDD 公司官网示例。包含首页、关于我们、业务介绍、发展历程以及联系我们等页面，整体采用蓝色科技风格。
+
+## 本地开发
+
+1. 安装依赖（需要联网）：
+
+   ```bash
+   pnpm install # 或 npm install
+   ```
+
+2. 启动开发服务器：
+
+   ```bash
+   pnpm dev # 或 npm run dev
+   ```
+
+浏览器访问 `http://localhost:3000` 即可查看网站。
+
+## 构建与部署
+
+```bash
+pnpm build # 或 npm run build
+pnpm start # 或 npm start
+```
+
+构建后的静态文件位于 `.next` 目录，可用于生产环境部署。

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,10 @@
+export const metadata = { title: '关于我们 - AIDD' };
+
+export default function About() {
+  return (
+    <section>
+      <h1>关于我们</h1>
+      <p>AIDD是一家专注于人工智能和软件工程结合的创新公司，目标是以AI技术提升开发效率。</p>
+    </section>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = { title: '联系我们 - AIDD' };
+
+export default function Contact() {
+  return (
+    <section>
+      <h1>联系我们</h1>
+      <p>邮箱: contact@aidd.com</p>
+      <p>电话: 010-12345678</p>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,43 @@
+:root {
+  --primary-color: #0070f3;
+  --text-color: #333;
+  --bg-color: #f0f6ff;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+nav {
+  background: var(--primary-color);
+  padding: 1rem;
+}
+
+nav a {
+  color: white;
+  margin-right: 1rem;
+  font-weight: bold;
+}
+
+main {
+  padding: 2rem;
+}
+
+footer {
+  background: var(--primary-color);
+  color: white;
+  text-align: center;
+  padding: 1rem;
+  margin-top: 2rem;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'AIDD - AI Driven Development',
+  description: 'AIDD official website',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <nav>
+          <Link href="/">首页</Link>
+          <Link href="/about">关于我们</Link>
+          <Link href="/services">业务介绍</Link>
+          <Link href="/timeline">发展历程</Link>
+          <Link href="/contact">联系我们</Link>
+        </nav>
+        <main>{children}</main>
+        <footer>© {new Date().getFullYear()} AIDD</footer>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <section>
+      <h1>欢迎来到 AIDD</h1>
+      <p>AIDD致力于以人工智能驱动未来的软件开发。</p>
+    </section>
+  );
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,14 @@
+export const metadata = { title: '业务介绍 - AIDD' };
+
+export default function Services() {
+  return (
+    <section>
+      <h1>业务介绍</h1>
+      <ul>
+        <li>AI驱动的软件开发平台</li>
+        <li>企业级解决方案咨询</li>
+        <li>定制化AI模型训练</li>
+      </ul>
+    </section>
+  );
+}

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -1,0 +1,14 @@
+export const metadata = { title: '发展历程 - AIDD' };
+
+export default function Timeline() {
+  return (
+    <section>
+      <h1>发展历程</h1>
+      <ol>
+        <li>2020 - 公司成立，专注于AI研发</li>
+        <li>2021 - 推出第一代AI辅助开发工具</li>
+        <li>2023 - 拓展国际市场，服务全球客户</li>
+      </ol>
+    </section>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: { appDir: true }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "codexsite",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "@types/react"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project
- add blue themed layout and pages
- update README with usage instructions

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777a88f8708330872fb405a40a4a2f